### PR TITLE
fix: allow to install with unsupported cpu

### DIFF
--- a/common/templates/esxi-ks.cfg
+++ b/common/templates/esxi-ks.cfg
@@ -1,6 +1,6 @@
 vmaccepteula
 rootpw {{.Password}}
-install --firstdisk --overwritevmfs
+install --firstdisk --overwritevmfs --forceunsupportedinstall
 network --bootproto=static --ip={{.IP}} --netmask={{.Netmask}} --gateway={{.Gateway}} --nameserver={{.Nameserver}} --hostname={{.Hostname}} --device=vmnic0 {{if .VLANID}} --vlanid={{.VLANID}} {{else}} --vlanid=0 {{end}} {{if .NotVmPgCreate }} --addvmportgroup=0 {{ else }} --addvmportgroup=1 {{ end }}
 {{if .Keyboard}}
 keyboard "{{.Keyboard}}"


### PR DESCRIPTION
Since esxi 8, checks for old CPUs have become stricter, so I add option to allow installs even on unsupported CPUs.  
- https://williamlam.com/2022/10/quick-tip-automating-esxi-8-0-install-using-allowlegacycputrue.html  
- https://kb.vmware.com/s/article/82794

verified version is following.
- 8.0U1a
- 7.0U3g
- 6.7U2